### PR TITLE
Sync backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /target
 history.db
+
+*.db
+*.db-journal
+
+Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,6 +1804,7 @@ dependencies = [
  "ic-agent",
  "rusqlite",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 ic-agent = "0.7.0"
 tokio = { version = "1.8.1", features = ["full"] }
 rusqlite = "0.25.3"
+serde_json = "1.0"

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     },
     {
         "canister_id": "42vp6-2iaaa-aaaah-qbooa-cai",
-        "canister_type": "token-burn",
+        "canister_type": "wicp",
         "db": "./b.db"
     },
     {

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     },
     {
         "canister_id": "42vp6-2iaaa-aaaah-qbooa-cai",
-        "canister_type": "token",
+        "canister_type": "token-burn",
         "db": "./b.db"
     },
     {

--- a/config.json
+++ b/config.json
@@ -1,0 +1,22 @@
+[
+    {
+        "canister_id": "5l7rb-caaaa-aaaah-qbolq-cai",
+        "canister_type": "token",
+        "db": "./a.db"
+    },
+    {
+        "canister_id": "42vp6-2iaaa-aaaah-qbooa-cai",
+        "canister_type": "token",
+        "db": "./b.db"
+    },
+    {
+        "canister_id": "4ps6t-3aaaa-aaaah-qbonq-cai",
+        "canister_type": "token-registry",
+        "db": "./c.db"
+    },
+    {
+        "canister_id": "4bqt3-aqaaa-aaaah-qbomq-cai",
+        "canister_type": "dswap-storage",
+        "db": "./d.db"
+    }
+]

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ async fn sync_canister(config: CanisterConfig) {
             }
             save_to_db(result.clone(), config.db.clone());
             result_len = result.len();
-        } else if config.canister_type == String::from("token-burn") {
+        } else if config.canister_type == String::from("wicp") {
             let history_size: Nat = get_history_size(&agent, config.canister_id.clone()).await;
             let raw_transactions = get_trasnactions(
                 &agent,

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn sync_canister(config: CanisterConfig) {
                 ),
             )
             .await;
-            let result = Decode!(raw_transactions.as_slice(), Vec<TxRecord>)
+            let result = Decode!(raw_transactions.as_slice(), Vec<TokenTxRecord>)
                 .expect("Failed to decode the getTransactions response data.");
             if result.len() > 0 {
                 println!(
@@ -93,7 +93,7 @@ async fn sync_canister(config: CanisterConfig) {
                 ),
             )
             .await;
-            let result = Decode!(raw_transactions.as_slice(), Vec<TxRecordBurn>)
+            let result = Decode!(raw_transactions.as_slice(), Vec<WICPTxRecord>)
                 .expect("Failed to decode the getTransactions response data.");
             if result.len() > 0 {
                 println!(
@@ -133,7 +133,7 @@ async fn sync_canister(config: CanisterConfig) {
                 ),
             )
             .await;
-            let result = Decode!(raw_transactions.as_slice(), Vec<DSwapOpRecord>)
+            let result = Decode!(raw_transactions.as_slice(), Vec<DSwapTxRecord>)
                 .expect("Failed to decode the getTransactions response data.");
             if result.len() > 0 {
                 println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
 use ic_agent::{Agent, identity::BasicIdentity, ic_types::Principal, agent::http_transport::ReqwestHttpReplicaV2Transport};
 use candid::{Encode, Decode, CandidType, types::number::{Nat, Int}};
 use serde::Deserialize;
-use std::{thread, time::Duration};
+use std::{fs, env, thread, time::Duration};
 use rusqlite::Connection;
-use std::env;
 
 mod types;
 
@@ -11,20 +10,37 @@ use types::*;
 
 const DEFAULT_IC_GATEWAY: &str = "https://ic0.app";
 const KEY_PATH: &str = "/Users/cyan/.config/dfx/identity/default/identity.pem";
-const DSWAP_STORAGE: &str = "gsf2f-kaaaa-aaaah-qaj4q-cai";
 const INTERVAL: u64 = 1 * 60 * 1000; // 1 min
 const INTERVAL_S: u64 = 0; // 0 s
 const QUERY_NUM: usize = 100;
 const QUERY_NUM_S: usize = 13000;
 
+#[derive(Debug, Deserialize)]
+struct CanisterConfig {
+    canister_id: String,
+    canister_type: String,
+    db: String,
+}
+
 #[tokio::main]
 async fn main() {
-    let args: Vec<String> = env::args().collect();
-    let mut begin: Nat = if args.len() < 2 {
-        Nat::from(0)
-    } else {
-        Nat::from(args[1].parse::<u64>().expect("input not number"))
-    };
+    let config_data = fs::read_to_string("config.json").expect("Unable to read config file");
+    let config_list: Vec<CanisterConfig> = serde_json::from_str(&config_data[..]).unwrap();
+    let mut join_handle_list = vec![];
+    for config in config_list {
+        println!("Starting following canister: {:?}", config);
+        let handle = tokio::spawn(async move {
+            sync_canister(config).await;
+        });
+        join_handle_list.push(handle);
+    }
+    for handle in join_handle_list {
+        handle.await.unwrap();
+    }
+}
+
+async fn sync_canister(config: CanisterConfig) {
+    let mut begin: Nat = Nat::from(0);
 
     let agent = Agent::builder()
         .with_transport(
@@ -34,39 +50,153 @@ async fn main() {
         .with_identity(create_identity())
         .build()
         .expect("Failed to build the Agent");
-    
+
     let mut num = QUERY_NUM_S;
     let mut interval = 0;
-    loop {        
-        let response = agent.query(&Principal::from_text(DSWAP_STORAGE).expect("Failed to convert DSWAP_STORAGE to principal"), "getHistory")
+    loop {
+        if config.canister_type == String::from("token") {
+            let response = agent.query(&Principal::from_text(config.canister_id.clone()).expect("Failed to convert token to principal"), "getTransactions")
             .with_arg(&Encode!(&begin, &Nat::from(num)).unwrap())
             .call()
             .await
             .expect("Failed to call canister");
 
-        let result = Decode!(response.as_slice(), Vec<DSwapOpRecord>).expect("Failed to decode the response data.");
-        save_to_db(result.clone());
-        println!("from {} to {}", begin.clone(), begin.clone() + result.len() - 1);
-        if result.len() < num {
-            begin += result.len();
-            num = QUERY_NUM;
-            interval = INTERVAL;
-            thread::sleep(Duration::from_millis(interval));
-        } else {
-            begin += num;
-            num = QUERY_NUM_S;
-            interval = INTERVAL_S;
-            thread::sleep(Duration::from_millis(interval));
+            let result = Decode!(response.as_slice(), Vec<TxRecord>).expect("Failed to decode the getTransactions response data.");
+            println!("Read from {} to {} from token canister", begin.clone(), begin.clone() + result.len() - 1);
+            save_transactions_to_db(result.clone(), config.db.clone());
+
+            if result.len() < num {
+                begin += result.len();
+                num = QUERY_NUM;
+                interval = INTERVAL;
+                thread::sleep(Duration::from_millis(interval));
+            } else {
+                begin += num;
+                num = QUERY_NUM_S;
+                interval = INTERVAL_S;
+                thread::sleep(Duration::from_millis(interval));
+            }
+        } else if config.canister_type == String::from("token-registry") {
+            let response = agent.query(&Principal::from_text(config.canister_id.clone()).expect("Failed to convert token-registry to principal"), "getTokens")
+            .with_arg(&Encode!(&begin, &Nat::from(num)).unwrap())
+            .call()
+            .await
+            .expect("Failed to call canister");
+
+            let result = Decode!(response.as_slice(), Vec<TokenInfo>).expect("Failed to decode the getTokens response data.");
+            println!("Read from {} to {} from token-registry canister", begin.clone(), begin.clone() + result.len() - 1);
+            save_tokens_to_db(result.clone(), config.db.clone());
+
+            if result.len() < num {
+                begin += result.len();
+                num = QUERY_NUM;
+                interval = INTERVAL;
+                thread::sleep(Duration::from_millis(interval));
+            } else {
+                begin += num;
+                num = QUERY_NUM_S;
+                interval = INTERVAL_S;
+                thread::sleep(Duration::from_millis(interval));
+            }
+        } else if config.canister_type == String::from("dswap-storage") {
+            let response = agent.query(&Principal::from_text(config.canister_id.clone()).expect("Failed to convert dswap-storage to principal"), "getTransactions")
+            .with_arg(&Encode!(&begin, &Nat::from(num)).unwrap())
+            .call()
+            .await
+            .expect("Failed to call canister");
+
+            let result = Decode!(response.as_slice(), Vec<DSwapOpRecord>).expect("Failed to decode the response data.");
+            println!("Read from {} to {} from dswap canister", begin.clone(), begin.clone() + result.len() - 1);
+            save_dswaps_to_db(result.clone(), config.db.clone());
+
+            if result.len() < num {
+                begin += result.len();
+                num = QUERY_NUM;
+                interval = INTERVAL;
+                thread::sleep(Duration::from_millis(interval));
+            } else {
+                begin += num;
+                num = QUERY_NUM_S;
+                interval = INTERVAL_S;
+                thread::sleep(Duration::from_millis(interval));
+            }
         }
     }
 }
 
-fn save_to_db(data: Vec<DSwapOpRecord>) {
-    println!("{:?}", data.len());
-    let conn = Connection::open("history.db").expect("Failed to open history.db");
+fn save_transactions_to_db(data: Vec<TxRecord>, db_name: String) {
+    println!("Writing {:?} token transaction rows to db.", data.len());
+    let conn = Connection::open(&db_name[..]).expect("Failed to open db.");
 
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS history (
+        "CREATE TABLE IF NOT EXISTS transactions (
+            id            INTEGER PRIMARY KEY,
+            indexs        INTEGER NOT NULL,
+            caller        TEXT NOT NULL,
+            op            TEXT NOT NULL,
+            froma         TEXT NOT NULL,
+            toa           TEXT NOT NULL,
+            amount        INTEGER NOT NULL,
+            fee           INTEGER NOT NULL,
+            timestamp     INTEGER NOT NULL
+        )",
+        [],
+    ).expect("Failed to create new transactions table.");
+
+    for i in data {
+        let caller_or_none: String;
+        if i.caller.is_none() {
+            caller_or_none = String::from("None");
+        } else {
+            caller_or_none = i.caller.unwrap().to_string();
+        }
+        conn.execute(
+            "INSERT INTO transactions (indexs, caller, op, froma, toa, amount, fee, timestamp)
+            values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            &[&i.index.to_string(), &caller_or_none, &i.op.to_text(), &i.from.to_text().to_string(),
+            &i.to.to_text().to_string(), &i.amount.to_string(), &i.fee.to_string(), &i.timestamp.to_string()],
+        ).expect("Failed to insert transaction to transactions table.");
+    } 
+}
+
+fn save_tokens_to_db(data: Vec<TokenInfo>, db_name: String) {
+    println!("Writing {:?} token info rows to db.", data.len());
+    let conn = Connection::open(&db_name[..]).expect("Failed to open db.");
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS tokens (
+            id            INTEGER PRIMARY KEY,
+            canisterId    TEXT NOT NULL,
+            decimals      INTEGER NOT NULL,
+            fee           INTEGER NOT NULL,
+            indexs        INTEGER NOT NULL,
+            logo          TEXT NOT NULL,
+            name          TEXT NOT NULL,
+            owner         TEXT NOT NULL,
+            symbol        TEXT NOT NULL,
+            timestamp     INTEGER NOT NULL,
+            totalSupply   INTEGER NOT NULL
+        )",
+        [],
+    ).expect("Failed to create new tokens table.");
+
+    for i in data {
+        conn.execute(
+            "INSERT INTO tokens (canisterId, decimals, fee, indexs, logo, name, owner, symbol, timestamp, totalSupply)
+            values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            &[&i.canisterId.to_text().to_string(), &i.decimals.to_string(), &i.fee.to_string(), &i.index.to_string(), 
+            &i.logo.to_string(), &i.name.to_string(), &i.owner.to_text().to_string(), &i.symbol.to_string(),
+            &i.timestamp.to_string(), &i.totalSupply.to_string()],
+        ).expect("Failed to insert token info to tokens table.");
+    } 
+}
+
+fn save_dswaps_to_db(data: Vec<DSwapOpRecord>, db_name: String) {
+    println!("Writing {:?} dswap transaction rows to db.", data.len());
+    let conn = Connection::open(&db_name[..]).expect("Failed to open db.");
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS transactions (
             id            INTEGER PRIMARY KEY,
             caller        TEXT NOT NULL,
             op            TEXT NOT NULL,
@@ -80,31 +210,16 @@ fn save_to_db(data: Vec<DSwapOpRecord>) {
             timestamp     INTEGER NOT NULL
         )",
         [],
-    ).expect("Failed to new history table.");
+    ).expect("Failed to new transactions table.");
 
     for i in data {
         conn.execute(
-            "INSERT INTO history (caller, op, indexs, token_id, froma, toa, amount, amount0, amount1, timestamp)
+            "INSERT INTO transactions (caller, op, indexs, token_id, froma, toa, amount, amount0, amount1, timestamp)
             values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-            &[&i.caller.to_text().to_string(), &op_to_text(i.op), &i.index.to_string(), &i.tokenId, &i.from.to_text().to_string(),
+            &[&i.caller.to_text().to_string(), &i.op.to_text(), &i.index.to_string(), &i.tokenId, &i.from.to_text().to_string(),
             &i.to.to_text().to_string(), &i.amount.to_string(), &i.amount0.to_string(), &i.amount1.to_string(), &i.timestamp.to_string()],
-        ).expect("Failed to insert ops to historay table.");
+        ).expect("Failed to insert ops to transactions table.");
     } 
-}
-
-fn op_to_text(o: DSwapOperation) -> String {
-    match o {
-        DSwapOperation::deposit => String::from("deposit"),
-        DSwapOperation::withdraw => String::from("withdraw"),
-        DSwapOperation::tokenTransfer => String::from("tokenTransfer"),
-        DSwapOperation::tokenApprove => String::from("tokenApprove"),
-        DSwapOperation::lpTransfer => String::from("lpTransfer"),
-        DSwapOperation::lpApprove => String::from("lpApprove"),
-        DSwapOperation::createPair => String::from("createPair"),
-        DSwapOperation::swap => String::from("swap"),
-        DSwapOperation::addLiquidity => String::from("addLiquidity"),
-        DSwapOperation::removeLiquidity => String::from("removeLiquidity"),
-    }
 }
 
 fn create_identity() -> BasicIdentity {

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,7 +59,7 @@ pub struct DSwapTxRecord {
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum TokenOperation {
     mint,
-    burn(u64),
+    burn,
     transfer,
     transferFrom,
     approve
@@ -70,7 +70,7 @@ impl TokenOperation {
         match self {
             Self::approve => String::from("approve"),
             Self::mint => String::from("mint"),
-            Self::burn(c) => format!("burn {}", c),
+            Self::burn => String::from("burn"),
             Self::transfer => String::from("transfer"),
             Self::transferFrom => String::from("transferFrom"),
         }
@@ -89,39 +89,39 @@ pub struct TokenTxRecord {
     pub timestamp: Int,
 }
 
-// #[allow(non_camel_case_types)]
-// #[derive(CandidType, Deserialize, Clone, Debug)]
-// pub enum WICPOperation {
-//     approve,
-//     burn(u64),
-//     mint,
-//     transfer,
-//     transferFrom,
-// }
+#[allow(non_camel_case_types)]
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum WICPOperation {
+    approve,
+    burn(u64),
+    mint,
+    transfer,
+    transferFrom,
+}
 
-// impl WICPOperation {
-//     pub fn to_text(&self) -> String {
-//         match self {
-//             Self::approve => String::from("approve"),
-//             Self::burn(c) => format!("burn {}", c),
-//             Self::mint => String::from("mint"),
-//             Self::transfer => String::from("transfer"),
-//             Self::transferFrom => String::from("transferFrom"),
-//         }
-//     }
-// }
+impl WICPOperation {
+    pub fn to_text(&self) -> String {
+        match self {
+            Self::approve => String::from("approve"),
+            Self::burn(c) => format!("burn {}", c),
+            Self::mint => String::from("mint"),
+            Self::transfer => String::from("transfer"),
+            Self::transferFrom => String::from("transferFrom"),
+        }
+    }
+}
 
-// #[derive(CandidType, Deserialize, Clone, Debug)]
-// pub struct WICPTxRecord {
-//     pub index: Nat,
-//     pub caller: Option<Principal>,
-//     pub op: TxTokenOperationBurn,
-//     pub from: Principal,
-//     pub to: Principal,
-//     pub amount: Nat,
-//     pub fee: Nat,
-//     pub timestamp: Int,
-// }
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct WICPTxRecord {
+    pub index: Nat,
+    pub caller: Option<Principal>,
+    pub op: TxTokenOperationBurn,
+    pub from: Principal,
+    pub to: Principal,
+    pub amount: Nat,
+    pub fee: Nat,
+    pub timestamp: Int,
+}
 
 #[allow(non_snake_case)]
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -185,46 +185,46 @@ impl Database for TokenTxRecord {
     }
 }
 
-// impl Database for WICPTxRecord {
-//     fn db_init_command(&self) -> &str {
-//         return "CREATE TABLE IF NOT EXISTS transactions (
-//                     id            INTEGER PRIMARY KEY,
-//                     indexs        INTEGER NOT NULL,
-//                     caller        TEXT NOT NULL,
-//                     op            TEXT NOT NULL,
-//                     froma         TEXT NOT NULL,
-//                     toa           TEXT NOT NULL,
-//                     amount        INTEGER NOT NULL,
-//                     fee           INTEGER NOT NULL,
-//                     timestamp     INTEGER NOT NULL
-//                 )";
-//     }
+impl Database for WICPTxRecord {
+    fn db_init_command(&self) -> &str {
+        return "CREATE TABLE IF NOT EXISTS transactions (
+                    id            INTEGER PRIMARY KEY,
+                    indexs        INTEGER NOT NULL,
+                    caller        TEXT NOT NULL,
+                    op            TEXT NOT NULL,
+                    froma         TEXT NOT NULL,
+                    toa           TEXT NOT NULL,
+                    amount        INTEGER NOT NULL,
+                    fee           INTEGER NOT NULL,
+                    timestamp     INTEGER NOT NULL
+                )";
+    }
 
-//     fn db_insert_header(&self) -> &str {
-//         return "INSERT INTO transactions (indexs, caller, op, froma, toa, amount, fee, timestamp)
-//                 values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
-//     }
+    fn db_insert_header(&self) -> &str {
+        return "INSERT INTO transactions (indexs, caller, op, froma, toa, amount, fee, timestamp)
+                values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
+    }
 
-//     fn db_insert_values(&self) -> Vec<String> {
-//         let caller_or_none: String;
-//         if self.caller.is_none() {
-//             caller_or_none = String::from("None");
-//         } else {
-//             caller_or_none = self.caller.unwrap().to_string();
-//         }
-//         let ret = vec![
-//             self.index.to_string(),
-//             caller_or_none,
-//             self.op.to_text(),
-//             self.from.to_text().to_string(),
-//             self.to.to_text().to_string(),
-//             self.amount.to_string(),
-//             self.fee.to_string(),
-//             self.timestamp.to_string(),
-//         ];
-//         return ret;
-//     }
-// }
+    fn db_insert_values(&self) -> Vec<String> {
+        let caller_or_none: String;
+        if self.caller.is_none() {
+            caller_or_none = String::from("None");
+        } else {
+            caller_or_none = self.caller.unwrap().to_string();
+        }
+        let ret = vec![
+            self.index.to_string(),
+            caller_or_none,
+            self.op.to_text(),
+            self.from.to_text().to_string(),
+            self.to.to_text().to_string(),
+            self.amount.to_string(),
+            self.fee.to_string(),
+            self.timestamp.to_string(),
+        ];
+        return ret;
+    }
+}
 
 impl Database for TokenInfo {
     fn db_init_command(&self) -> &str {

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,6 +55,12 @@ pub struct DSwapTxRecord {
     timestamp: u64,
 }
 
+// TODO: 1. sync dswap pair info 2. calculate stats info for each pair: trading volume, fees, etc.
+// #[derive(Debug)]
+// pub struct DSwapPairInfo {
+   
+// }
+
 #[allow(non_camel_case_types)]
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum TokenOperation {

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,24 @@ pub enum DSwapOperation {
     createPair, swap, addLiquidity, removeLiquidity
 }
 
+impl DSwapOperation {
+    pub fn to_text(&self) -> String {
+        match self {
+            Self::deposit => String::from("deposit"),
+            Self::withdraw => String::from("withdraw"),
+            Self::tokenTransfer => String::from("tokenTransfer"),
+            Self::tokenApprove => String::from("tokenApprove"),
+            Self::lpTransfer => String::from("lpTransfer"),
+            Self::lpApprove => String::from("lpApprove"),
+            Self::createPair => String::from("createPair"),
+            Self::swap => String::from("swap"),
+            Self::addLiquidity => String::from("addLiquidity"),
+            Self::removeLiquidity => String::from("removeLiquidity"),
+        }
+    }
+}
+
+
 #[allow(non_snake_case)]
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub struct DSwapOpRecord {
@@ -72,4 +90,48 @@ pub struct TokenHistory {
     amount: u64,
     fee: u64,
     timestamp: u64,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum TxTokenOperation {
+    approve, mint, transfer, transferFrom
+}
+
+impl TxTokenOperation {
+    pub fn to_text(&self) -> String {
+        match self {
+            Self::approve => String::from("approve"),
+            Self::mint => String::from("mint"),
+            Self::transfer => String::from("transfer"),
+            Self::transferFrom => String::from("transferFrom"),
+        }
+    }
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TxRecord {
+    pub index: Nat,
+    pub caller: Option<Principal>,
+    pub op: TxTokenOperation,
+    pub from: Principal,
+    pub to: Principal,
+    pub amount: Nat,
+    pub fee: Nat,
+    pub timestamp: Int,
+}
+
+#[allow(non_snake_case)]
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TokenInfo {
+    pub canisterId: Principal,
+    pub decimals: u8, // Nat8
+    pub fee: Nat,
+    pub index: Nat,
+    pub logo: String,
+    pub name: String,
+    pub owner: Principal,
+    pub symbol: String,
+    pub timestamp: Int,
+    pub totalSupply: Nat,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -121,6 +121,36 @@ pub struct TxRecord {
     pub timestamp: Int,
 }
 
+#[allow(non_camel_case_types)]
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub enum TxTokenOperationBurn {
+    approve, burn(u64), mint, transfer, transferFrom
+}
+
+impl TxTokenOperationBurn {
+    pub fn to_text(&self) -> String {
+        match self {
+            Self::approve => String::from("approve"),
+            Self::burn(c) => format!("burn {}", c),
+            Self::mint => String::from("mint"),
+            Self::transfer => String::from("transfer"),
+            Self::transferFrom => String::from("transferFrom"),
+        }
+    }
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug)]
+pub struct TxRecordBurn {
+    pub index: Nat,
+    pub caller: Option<Principal>,
+    pub op: TxTokenOperationBurn,
+    pub from: Principal,
+    pub to: Principal,
+    pub amount: Nat,
+    pub fee: Nat,
+    pub timestamp: Int,
+}
+
 #[allow(non_snake_case)]
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub struct TokenInfo {

--- a/src/types.rs
+++ b/src/types.rs
@@ -41,18 +41,19 @@ impl DSwapOperation {
     }
 }
 
-#[derive(Debug)]
+#[allow(non_snake_case)]
+#[derive(CandidType, Deserialize, Clone, Debug)]
 pub struct DSwapTxRecord {
-    index: u64,
-    caller: String,
+    index: Nat,
+    caller: Principal,
     op: DSwapOperation,
-    token_id: String,
-    from: String,
-    to: String,
-    amount: u64,
-    amount0: u64,
-    amount1: u64,
-    timestamp: u64,
+    tokenId: String,
+    from: Principal,
+    to: Principal,
+    amount: Nat,
+    amount0: Nat,
+    amount1: Nat,
+    timestamp: Int,
 }
 
 // TODO: 1. sync dswap pair info 2. calculate stats info for each pair: trading volume, fees, etc.
@@ -121,7 +122,7 @@ impl WICPOperation {
 pub struct WICPTxRecord {
     pub index: Nat,
     pub caller: Option<Principal>,
-    pub op: TxTokenOperationBurn,
+    pub op: WICPOperation,
     pub from: Principal,
     pub to: Principal,
     pub amount: Nat,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,16 +1,23 @@
-use ic_agent::{Agent, identity::BasicIdentity, ic_types::Principal, agent::http_transport::ReqwestHttpReplicaV2Transport};
-use candid::{Encode, Decode, CandidType, types::number::{Nat, Int}};
+use candid::{
+    types::number::{Int, Nat},
+    CandidType,
+};
+use ic_agent::ic_types::Principal;
 use serde::Deserialize;
-use std::{thread, time::Duration};
-use rusqlite::Connection;
-use std::env;
 
 #[allow(non_camel_case_types)]
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum DSwapOperation {
-    deposit, withdraw, tokenTransfer, tokenApprove,
-    lpTransfer, lpApprove, 
-    createPair, swap, addLiquidity, removeLiquidity
+    deposit,
+    withdraw,
+    tokenTransfer,
+    tokenApprove,
+    lpTransfer,
+    lpApprove,
+    createPair,
+    swap,
+    addLiquidity,
+    removeLiquidity,
 }
 
 impl DSwapOperation {
@@ -29,7 +36,6 @@ impl DSwapOperation {
         }
     }
 }
-
 
 #[allow(non_snake_case)]
 #[derive(CandidType, Deserialize, Clone, Debug)]
@@ -60,11 +66,14 @@ pub struct DSwapHistory {
     timestamp: u64,
 }
 
-
 #[allow(non_camel_case_types)]
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum TokenOperation {
-    mint, burn, transfer, approve, init
+    mint,
+    burn,
+    transfer,
+    approve,
+    init,
 }
 
 #[allow(non_snake_case)]
@@ -95,7 +104,10 @@ pub struct TokenHistory {
 #[allow(non_camel_case_types)]
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum TxTokenOperation {
-    approve, mint, transfer, transferFrom
+    approve,
+    mint,
+    transfer,
+    transferFrom,
 }
 
 impl TxTokenOperation {
@@ -124,7 +136,11 @@ pub struct TxRecord {
 #[allow(non_camel_case_types)]
 #[derive(CandidType, Deserialize, Clone, Debug)]
 pub enum TxTokenOperationBurn {
-    approve, burn(u64), mint, transfer, transferFrom
+    approve,
+    burn(u64),
+    mint,
+    transfer,
+    transferFrom,
 }
 
 impl TxTokenOperationBurn {
@@ -164,4 +180,170 @@ pub struct TokenInfo {
     pub symbol: String,
     pub timestamp: Int,
     pub totalSupply: Nat,
+}
+
+pub trait Database {
+    fn db_init_command(&self) -> &str;
+    fn db_insert_header(&self) -> &str;
+    fn db_insert_values(&self) -> Vec<String>;
+}
+
+impl Database for TxRecord {
+    fn db_init_command(&self) -> &str {
+        return "CREATE TABLE IF NOT EXISTS transactions (
+                    id            INTEGER PRIMARY KEY,
+                    indexs        INTEGER NOT NULL,
+                    caller        TEXT NOT NULL,
+                    op            TEXT NOT NULL,
+                    froma         TEXT NOT NULL,
+                    toa           TEXT NOT NULL,
+                    amount        INTEGER NOT NULL,
+                    fee           INTEGER NOT NULL,
+                    timestamp     INTEGER NOT NULL
+                )";
+    }
+
+    fn db_insert_header(&self) -> &str {
+        return "INSERT INTO transactions (indexs, caller, op, froma, toa, amount, fee, timestamp)
+                values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
+    }
+
+    fn db_insert_values(&self) -> Vec<String> {
+        let caller_or_none: String;
+        if self.caller.is_none() {
+            caller_or_none = String::from("None");
+        } else {
+            caller_or_none = self.caller.unwrap().to_string();
+        }
+        let ret = vec![
+            self.index.to_string(),
+            caller_or_none,
+            self.op.to_text(),
+            self.from.to_text().to_string(),
+            self.to.to_text().to_string(),
+            self.amount.to_string(),
+            self.fee.to_string(),
+            self.timestamp.to_string(),
+        ];
+        return ret;
+    }
+}
+
+impl Database for TxRecordBurn {
+    fn db_init_command(&self) -> &str {
+        return "CREATE TABLE IF NOT EXISTS transactions (
+                    id            INTEGER PRIMARY KEY,
+                    indexs        INTEGER NOT NULL,
+                    caller        TEXT NOT NULL,
+                    op            TEXT NOT NULL,
+                    froma         TEXT NOT NULL,
+                    toa           TEXT NOT NULL,
+                    amount        INTEGER NOT NULL,
+                    fee           INTEGER NOT NULL,
+                    timestamp     INTEGER NOT NULL
+                )";
+    }
+
+    fn db_insert_header(&self) -> &str {
+        return "INSERT INTO transactions (indexs, caller, op, froma, toa, amount, fee, timestamp)
+                values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
+    }
+
+    fn db_insert_values(&self) -> Vec<String> {
+        let caller_or_none: String;
+        if self.caller.is_none() {
+            caller_or_none = String::from("None");
+        } else {
+            caller_or_none = self.caller.unwrap().to_string();
+        }
+        let ret = vec![
+            self.index.to_string(),
+            caller_or_none,
+            self.op.to_text(),
+            self.from.to_text().to_string(),
+            self.to.to_text().to_string(),
+            self.amount.to_string(),
+            self.fee.to_string(),
+            self.timestamp.to_string(),
+        ];
+        return ret;
+    }
+}
+
+impl Database for TokenInfo {
+    fn db_init_command(&self) -> &str {
+        return "CREATE TABLE IF NOT EXISTS tokens (
+                    id            INTEGER PRIMARY KEY,
+                    canisterId    TEXT NOT NULL,
+                    decimals      INTEGER NOT NULL,
+                    fee           INTEGER NOT NULL,
+                    indexs        INTEGER NOT NULL,
+                    logo          TEXT NOT NULL,
+                    name          TEXT NOT NULL,
+                    owner         TEXT NOT NULL,
+                    symbol        TEXT NOT NULL,
+                    timestamp     INTEGER NOT NULL,
+                    totalSupply   INTEGER NOT NULL
+                )";
+    }
+
+    fn db_insert_header(&self) -> &str {
+        return "INSERT INTO tokens (canisterId, decimals, fee, indexs, logo, name, owner, symbol, timestamp, totalSupply)
+                values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)";
+    }
+
+    fn db_insert_values(&self) -> Vec<String> {
+        let ret = vec![
+            self.canisterId.to_text().to_string(),
+            self.decimals.to_string(),
+            self.fee.to_string(),
+            self.index.to_string(),
+            self.logo.to_string(),
+            self.name.to_string(),
+            self.owner.to_text().to_string(),
+            self.symbol.to_string(),
+            self.timestamp.to_string(),
+            self.totalSupply.to_string(),
+        ];
+        return ret;
+    }
+}
+
+impl Database for DSwapOpRecord {
+    fn db_init_command(&self) -> &str {
+        return "CREATE TABLE IF NOT EXISTS transactions (
+                    id            INTEGER PRIMARY KEY,
+                    caller        TEXT NOT NULL,
+                    op            TEXT NOT NULL,
+                    indexs        INTEGER NOT NULL,
+                    token_id      TEXT NOT NULL,
+                    froma          TEXT NOT NULL,
+                    toa            TEXT NOT NULL,
+                    amount        INTEGER NOT NULL,
+                    amount0       INTEGER NOT NULL,
+                    amount1       INTEGER NOT NULL,
+                    timestamp     INTEGER NOT NULL
+                )";
+    }
+
+    fn db_insert_header(&self) -> &str {
+        return "INSERT INTO transactions (caller, op, indexs, token_id, froma, toa, amount, amount0, amount1, timestamp)
+                values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)";
+    }
+
+    fn db_insert_values(&self) -> Vec<String> {
+        let ret = vec![
+            self.caller.to_text().to_string(),
+            self.op.to_text(),
+            self.index.to_string(),
+            self.tokenId.to_string(),
+            self.from.to_text().to_string(),
+            self.to.to_text().to_string(),
+            self.amount.to_string(),
+            self.amount0.to_string(),
+            self.amount1.to_string(),
+            self.timestamp.to_string(),
+        ];
+        return ret;
+    }
 }


### PR DESCRIPTION
Hi!
This is a submission for the [this](https://gitcoin.co/issue/dfinance-tech/sync/1/100026637) bounty on gitcoin.

The code reads canisters info from config file and spawns a tokio task for each canister to periodically sync canister data to specified db.
I couldn't find any docs about the query limits. So I assumed they all work with previously set values (`QUERY_NUM = 100` and `QUERY_NUM_S = 13000`).
Tested with my own identity key and it works well, but changed the `KEY_PATH` to what it was before.
I removed the part of code which gets the `begin` parameter from env args and set it to `0` everytime for each canister. Let me know if you like to handle it another way.

It doesn't work for these 2 canisters:
1. token canister with id `42vp6-2iaaa-aaaah-qbooa-cai`. Because it has a slightly different candid than the token candid provided. It has an additional field (`burn: nat64`) in `Operation` type. So it can't be decoded.
2. dsawp-storage canister with id `4bqt3-aqaaa-aaaah-qbomq-cai`. Because there seems to be a problem with its `getTransactions` service. I even checked it in Candid UI and it shows this error:
`Call was rejected:
Request ID: 0cd71497fe889f546036010d150df05956aff43dacb80fe7db5f07882a604c3b
Reject code: 
Reject text: Canister 4bqt3-aqaaa-aaaah-qbomq-cai trapped explicitly: assertion failed at /Users/cyan/Desktop/blockchain/dfn/dfinance/backend-monorepo/dswap/src/storage.mo:243.9-243.46`
But, I tested the code with the dswap-storage canister which was already in the code (`gsf2f-kaaaa-aaaah-qaj4q-cai`). Tested the code with its `getHistory` service and it works well. It should work for the other one too because response types are the same.

Let me know if you need anything else! :hand: 